### PR TITLE
[0.1.5] Update to the latest STACS container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stacscan/stacs:0.4.4-r013cec8
+FROM stacscan/stacs:0.4.4-r9cff04b
 
 # Default environment variables.
 ENV FAIL_BUILD=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stacscan/stacs:0.4.4-r57ce3ce
+FROM stacscan/stacs:0.4.4-r013cec8
 
 # Default environment variables.
 ENV FAIL_BUILD=true

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ trigger was not a pull-request, findings will instead be printed to the console 
 STACS CI will exit with a non-zero status (`100`) if unsupressed findings were present.
 
 ```yaml
-uses: stacscan/stacs-ci@0.1.4
+uses: stacscan/stacs-ci@0.1.5
 ```
 
 The following example scans a sub-directory in the repository. In this example the 
@@ -101,7 +101,7 @@ The following example scans a sub-directory in the repository. In this example t
 of a Github actions pipeline.
 
 ```yaml
-uses: stacscan/stacs-ci@0.1.4
+uses: stacscan/stacs-ci@0.1.5
 with:
     scan-directory: 'binaries/'
 ```
@@ -110,7 +110,7 @@ The following example disables 'failing the build' if there are findings which h
 been ignored / suppressed.
 
 ```yaml
-uses: stacscan/stacs-ci@0.1.4
+uses: stacscan/stacs-ci@0.1.5
 with:
     fail-build: false
 ```

--- a/stacs/ci/__about__.py
+++ b/stacs/ci/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs-ci"
 __summary__ = "Static Token And Credential Scanner CI Integrations."
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs-integration/"
 __license__ = "BSD-3-Clause"


### PR DESCRIPTION
## Overview

**PLEASE NOTE**: There is a **potentially breaking change** as part of this update, as the Stripe rule has been relocated under `SaaS`. This modifies its reference to now be `CredentialSaaSStripeAPI`. Any previously suppressed findings for this rule will need to be updated to reflect this new identifier.

### 🛠️ **New Features**
* Upgrade to the [latest STACS rules](https://github.com/stacscan/stacs-rules/pull/6), which includes new rules for
  * PyPI Token
  * Slack Token
    * User (`xoxp-...`)
    * Bot (`xoxb-...`)
  * NPM
    * `authToken`
    * `password`
  * PKCS#12 / PFX
  * DER format RSA keys.
    * Detects keys with exponents `3` / `65537`, and modulous sizes `64` / `128` / `256` / `512` / `1024`.

### 🍩 **Improvements**
* Minor changes to AWS rule.
* Simplify matching criteria for a number of rules.

### 🐛 **Bug Fixes**
* N/A
