### PR TITLE
[0.1.6] Update to the latest STACS container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ trigger was not a pull-request, findings will instead be printed to the console 
 STACS CI will exit with a non-zero status (`100`) if unsupressed findings were present.
 
 ```yaml
-uses: stacscan/stacs-ci@0.1.5
+uses: stacscan/stacs-ci@0.1.6
 ```
 
 The following example scans a sub-directory in the repository. In this example the 
@@ -101,7 +101,7 @@ The following example scans a sub-directory in the repository. In this example t
 of a Github actions pipeline.
 
 ```yaml
-uses: stacscan/stacs-ci@0.1.5
+uses: stacscan/stacs-ci@0.1.6
 with:
     scan-directory: 'binaries/'
 ```
@@ -110,7 +110,7 @@ The following example disables 'failing the build' if there are findings which h
 been ignored / suppressed.
 
 ```yaml
-uses: stacscan/stacs-ci@0.1.5
+uses: stacscan/stacs-ci@0.1.6
 with:
     fail-build: false
 ```

--- a/stacs/ci/__about__.py
+++ b/stacs/ci/__about__.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 __title__ = "stacs-ci"
 __summary__ = "Static Token And Credential Scanner CI Integrations."
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __author__ = "Peter Adkins"
 __uri__ = "https://www.github.com/stacscan/stacs-integration/"
 __license__ = "BSD-3-Clause"


### PR DESCRIPTION
### Overview

Upgrades to the latest STACS container. See the [STACS release notes](https://github.com/stacscan/stacs/releases/tag/0.4.5) for the new version for a list of changes in this container. Only changes to STACS-CI will be included below.

### 🛠️ **New Features**
* N/A

### 🍩 **Improvements**
* N/A

### 🐛 **Bug Fixes**
* N/A
